### PR TITLE
now uses c++ thread hardware_concurrency function

### DIFF
--- a/silicon/backends/mhd.hh
+++ b/silicon/backends/mhd.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <sys/sysinfo.h>
+#include <thread>
 #include <microhttpd.h>
 #include <stdlib.h>
 #include <string.h>
@@ -232,7 +232,7 @@ namespace sl
     else if (options.has(_linux_epoll))
       flags = MHD_USE_EPOLL_INTERNALLY_LINUX_ONLY;
 
-    int thread_pool_size = options.get(_nthreads, get_nprocs());
+    int thread_pool_size = options.get(_nthreads, std::thread::hardware_concurrency();
 
     auto api2 = api.bind_factories(mhd_session_cookie(), mhd_get_parameters_factory());
     auto s = service<mhd_json_service_utils, decltype(api2), mhd_request*, mhd_response*, MHD_Connection*>(api2);
@@ -248,7 +248,7 @@ namespace sl
         NULL,
         &mhd_handler<S>,
         &s,
-        MHD_OPTION_THREAD_POOL_SIZE, get_nprocs(),
+        MHD_OPTION_THREAD_POOL_SIZE, std::thread::hardware_concurrency(),
         MHD_OPTION_END);
     else
       d = MHD_start_daemon(


### PR DESCRIPTION
Using the c++ thread library to acquire hardware_concurrency instead of using sysinfo and get_nprocs() will allow this to run on mac as well, and not be dependent on linux specific libraries.